### PR TITLE
for android studio 3.0, with integer assign fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,7 +28,7 @@ buildscript {
 		jcenter()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:2.3.0'
+		classpath 'com.android.tools.build:gradle:3.0.1'
 	}
 }
 
@@ -42,7 +42,7 @@ allprojects {
 ext {
 	supportLibVersion = '25.1.0'  // variable that can be referenced to keep support libs consistent
 	commonLibVersion= '1.4.3'
-	versionBuildTool = '25.0.2'
+	versionBuildTool = '26.0.2'
 	versionCompiler = 25
 	versionTarget = 23
 	versionNameString = '1.0.0'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/src/main/jni/libusb/libusb/descriptor.c
+++ b/src/main/jni/libusb/libusb/descriptor.c
@@ -296,7 +296,7 @@ static int parse_interface(libusb_context *ctx,
 
 		/* Skip over any interface, class or vendor descriptors */
 		while (size >= LIBUSB_DT_HEADER_SIZE/*DESC_HEADER_LENGTH*/) {
-			usbi_parse_descriptor(buffer, "bb", &header, 0);
+			int len = usbi_parse_descriptor(buffer, "bb", &header, 0);
 			if UNLIKELY(header.bLength < LIBUSB_DT_HEADER_SIZE/*DESC_HEADER_LENGTH*/) {
 				usbi_err(ctx,
 					 "invalid extra intf desc len (%d)",


### PR DESCRIPTION
This update has two main parts:

- Update the gradle/buildtools so that it is all up to date for android studio 3. This means it's good for instant-run and several other features.

- I added a bugfix as noted in an issue on Saki's original repo. For reference the conversation can be seen here: https://github.com/saki4510t/UVCCamera/issues/181 , and the relevant fix is noted by "evgenek11" on October 8th.
    - the issue is catching the value returned from a function call in the .c code which shouldn't be an issue, but magically works. It is speculated that there is some issue in the NDK transition from gcc->clang which requires this fix.
    - this bugfix not only made things work with the new build tools on the pixel and building for Oreo, but it also fixed issues on devices like the moto g4 play and Durforce XD that previously would crash when trying to use USB camera. (whooohooo!)