### PR TITLE
make Android Studio 4.0 compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,7 +29,7 @@ buildscript {
 		google()
 	}
 	dependencies {
-		classpath 'com.android.tools.build:gradle:3.1.3'
+		classpath 'com.android.tools.build:gradle:4.0.0'
 	}
 }
 

--- a/src/main/AndroidManifest.xml
+++ b/src/main/AndroidManifest.xml
@@ -26,8 +26,5 @@
     android:versionCode="2"
     android:versionName="1.1" >
 
-    <uses-sdk
-        android:minSdkVersion="14"
-        android:targetSdkVersion="22" />
 
 </manifest>


### PR DESCRIPTION
In Android Studio 4.0, it wants all build specifics to be included in the build.gradle file and not in the AndroidManifest file. libuvccamera already specifies these in its build.gradle file, so the only real change is removing redundant/conflicting specifications from the manifest.

We also update the gradle build tools version.