### PR TITLE
Target Android 13

### DIFF
--- a/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -168,7 +168,7 @@ public final class USBMonitor {
 			if (DEBUG) Log.i(TAG, "register:");
 			final Context context = mWeakContext.get();
 			if (context != null) {
-				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), 0);
+				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 				final IntentFilter usbPermissionFilter = new IntentFilter(ACTION_USB_PERMISSION);
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				final IntentFilter usbDetachFilter = new IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED);

--- a/src/main/java/com/serenegiant/usb/USBMonitor.java
+++ b/src/main/java/com/serenegiant/usb/USBMonitor.java
@@ -44,6 +44,7 @@ import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbDeviceConnection;
 import android.hardware.usb.UsbInterface;
 import android.hardware.usb.UsbManager;
+import android.os.Build;
 import android.os.Handler;
 import android.text.TextUtils;
 import android.util.Log;
@@ -168,7 +169,11 @@ public final class USBMonitor {
 			if (DEBUG) Log.i(TAG, "register:");
 			final Context context = mWeakContext.get();
 			if (context != null) {
-				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
+				int flags = PendingIntent.FLAG_UPDATE_CURRENT;
+				if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+					flags = flags | PendingIntent.FLAG_IMMUTABLE;
+				}
+				mPermissionIntent = PendingIntent.getBroadcast(context, 0, new Intent(ACTION_USB_PERMISSION), flags);
 				final IntentFilter usbPermissionFilter = new IntentFilter(ACTION_USB_PERMISSION);
 				// ACTION_USB_DEVICE_ATTACHED never comes on some devices so it should not be added here
 				final IntentFilter usbDetachFilter = new IntentFilter(UsbManager.ACTION_USB_DEVICE_DETACHED);


### PR DESCRIPTION
https://developer.android.com/about/versions/12/behavior-changes-12#pending-intent-mutability

If your app targets Android 12, you must [specify the mutability](https://developer.android.com/guide/components/intents-filters#DeclareMutabilityPendingIntent) of each [PendingIntent](https://developer.android.com/reference/android/app/PendingIntent) object that your app creates. This additional requirement improves your app's security.