### PR TITLE
Refactor to AndroidX

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,5 +103,5 @@ task ndkBuild(type: Exec, description: 'Compile JNI source via NDK') {
 dependencies {
     implementation fileTree(dir: new File(buildDir, 'libs'), include: '*.jar')
     implementation(name: 'vl-serenegiant-common-release-1.4.3', ext: 'aar')
-    implementation "com.android.support:support-annotations:${supportLibVersion}"
+    implementation 'androidx.annotation:annotation:1.3.0'
 }

--- a/src/main/java/com/serenegiant/common/BaseActivity.java
+++ b/src/main/java/com/serenegiant/common/BaseActivity.java
@@ -30,10 +30,12 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
+
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import com.serenegiant.dialog.MessageDialogFragment;
 import com.serenegiant.utils.BuildCheck;

--- a/src/main/java/com/serenegiant/common/BaseFragment.java
+++ b/src/main/java/com/serenegiant/common/BaseFragment.java
@@ -30,10 +30,12 @@ import android.content.pm.PackageManager;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.NonNull;
-import android.support.annotation.StringRes;
+
 import android.util.Log;
 import android.widget.Toast;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.StringRes;
 
 import com.serenegiant.dialog.MessageDialogFragment;
 import com.serenegiant.utils.BuildCheck;


### PR DESCRIPTION
**Issue:**
We were using an outdated library (com.android.support) which have been deprecated for years and in 2018 google actually completely stopped any development on it.
To make our lives easier, google did not change the actual apis, so in order to migrate to androidX, we only needed to import androidx libraries and remove the legacy com.android.support ones. Android Studio has a tool that would do all the steps automatically (Refactor -> Migrate to AndroidX).

**Risk**
Besides touching many different files, the risk associated with this migration is minimum given that AndroidX is compatible with api 19 and higher.

**Implementation** 
Used the android tool to migrate to android x

**Test**
1) created a release apk (using k1 key)
2) Used our regression test cases and all tests passed (manual test)